### PR TITLE
Oauth1

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import env
 from worker import *
-from flask import Flask, request, render_template, redirect
+from flask import Flask, request, render_template, redirect, session
+import tweepy
 
 app = Flask(__name__)
 app.config.update(
@@ -19,6 +20,38 @@ def go():
     tweets = make_thread(text, preserve_whitespace)
     data = {'tweets':tweets}
     return render_template('index.html', data=data, page='go')
+
+@app.route('/auth', methods=['POST'])
+def auth():
+    try:
+        session['AUTH_TOKEN']
+        session['AUTH_TOKEN_SECRET']
+        redirect_url = '/share'
+    except Exception:
+        auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET, env.CALLBACK_URL)
+        redirect_url = auth.get_authorization_url()
+        session['REQUEST_TOKEN'] = auth.request_token
+    finally:
+        return redirect(redirect_url)
+
+@app.route('/callback', methods=['GET'])
+def callback():
+    auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET)
+    auth.request_token = session['REQUEST_TOKEN']
+    verifier = request.args.get('oauth_verifier')
+    try:
+        auth.get_access_token(verifier)
+        session['AUTH_TOKEN'],session['AUTH_TOKEN_SECRET'] = auth.access_token, auth.access_token_secret
+        redirect_url = '/share'
+    except Exception:
+        redirect_url = '/'
+    finally:
+        return redirect(redirect_url)
+
+@app.route('/share', methods=['GET'])
+def share():
+    data = {}
+    return render_template('index.html', data=data, page='share')
 
 @app.route('/alive', methods=['GET'])
 def alive():

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,14 @@
 
             {% endfor %}
 
+        <form class="" action="/auth" method="post">
+            <input type="submit" name="auth_button" value="Login to Twitter">
+        </form>
+
+        {% elif page == 'share' %}
+
+        <p>Share page coming soon!</p>
+
         {% elif page == 'alive' %}
 
         <p>App is alive!</p>


### PR DESCRIPTION
# Oauth1
Completed Oauth1 verification dance.
## Description
Modified `app.py` and `index.html` to add /auth, /callback, and /share routes. When a user wants to post their thread directly to Twitter through the app, the user is redirected to Twitter for authorization, then back to the /share route. The /auth and /callback routes do not render HTML templates.