### PR TITLE
Catch All

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,8 +55,7 @@ def share():
 
 @app.route('/alive', methods=['GET'])
 def alive():
-    data = {}
-    return render_template('index.html', data=data, page='alive')
+    return "Alive"
 
 @app.route('/', defaults={'path':''})
 @app.route('/<path:path>')

--- a/app.py
+++ b/app.py
@@ -37,9 +37,9 @@ def auth():
 @app.route('/callback', methods=['GET'])
 def callback():
     auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET)
-    auth.request_token = session['REQUEST_TOKEN']
-    verifier = request.args.get('oauth_verifier')
     try:
+        auth.request_token = session['REQUEST_TOKEN']
+        verifier = request.args.get('oauth_verifier')
         auth.get_access_token(verifier)
         session['AUTH_TOKEN'],session['AUTH_TOKEN_SECRET'] = auth.access_token, auth.access_token_secret
         redirect_url = '/share'

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ app.config.update(
     SECRET_KEY = env.APP_SECRET_KEY,
 )
 
-@app.route('/', methods=['GET'])
+@app.route('/home', methods=['GET'])
 def home():
     data = {}
     return render_template('index.html', data=data, page='home')
@@ -57,6 +57,11 @@ def share():
 def alive():
     data = {}
     return render_template('index.html', data=data, page='alive')
+
+@app.route('/', defaults={'path':''})
+@app.route('/<path:path>')
+def catch_all(path):
+    return redirect("/home")
 
 if __name__ == "__main__":
     app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,14 +33,6 @@
 
         <p>Share page coming soon!</p>
 
-        {% elif page == 'alive' %}
-
-        <p>App is alive!</p>
-
-        {% else %}
-
-        <p>ERROR: app route "{{page}}" not found!</p>
-
         {% endif %}
     </body>
 </html>


### PR DESCRIPTION
# Catch-All App Route
Added the `catch_all()` function and wildcard app routing. Also a few minor changes.
## Description
- The /alive route no longer renders index.html. Instead, plaintext "Alive" is returned. This is primarily to simplify index.html.
- A catch-all route was added. All unrecognized routes now redirect back to /home. This is also primarily to simplify index.html.
- Failed authorizations previously routed to /callback. This route was also accessible via any HTTP GET. All failed callbacks now reroute back to /home.