### PR TITLE
Preserve Whitespace - Bug Fix

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,27 +11,34 @@
 
         {% if page == 'home' %}
 
-        <form class="" action="/go" method="post">
-            <textarea name="thread_content" rows="20" cols="40"></textarea>
-            <input type="checkbox" name="preserve_whitespace" value="preserve_whitespace">Preserve whitespace?<br>
-            <input type="submit" name="submit_button" value="Go">
-        </form>
+            <form class="" action="/go" method="post">
+                <textarea name="thread_content" rows="20" cols="40"></textarea>
+                <input type="checkbox" name="preserve_whitespace" value="preserve_whitespace">Preserve whitespace?<br>
+                <input type="submit" name="submit_button" value="Go">
+            </form>
 
         {% elif page == 'go' %}
+
+            <form class="" action="/auth" method="post">
+                <input type="submit" name="auth_button" value="Login to Twitter">
+            </form>
+            <form class="" action="/home" method="get">
+                <input type="submit" name="home_button" value="Start Over">
+            </form>
 
             {% for tweet in data.tweets %}
 
                 <p style="white-space:pre;">{{tweet}}</p>
-                
-            {% endfor %}
 
-        <form class="" action="/auth" method="post">
-            <input type="submit" name="auth_button" value="Login to Twitter">
-        </form>
+            {% endfor %}
 
         {% elif page == 'share' %}
 
-        <p>Share page coming soon!</p>
+            <p>Share page coming soon!</p>
+
+            <form class="" action="/home" method="get">
+                <input type="submit" name="home_button" value="Start Over">
+            </form>
 
         {% endif %}
     </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
         {% if page == 'home' %}
 
         <form class="" action="/go" method="post">
-            <textarea name="thread_content" rows="8" cols="80"></textarea>
+            <textarea name="thread_content" rows="20" cols="40"></textarea>
             <input type="checkbox" name="preserve_whitespace" value="preserve_whitespace">Preserve whitespace?<br>
             <input type="submit" name="submit_button" value="Go">
         </form>
@@ -21,8 +21,8 @@
 
             {% for tweet in data.tweets %}
 
-                <p>{{tweet}}</p>
-
+                <p style="white-space:pre;">{{tweet}}</p>
+                
             {% endfor %}
 
         <form class="" action="/auth" method="post">


### PR DESCRIPTION
# Preserve Whitespace - Bug Fix
Small bug fix.
## Description
The preserve_whitespace flag made no difference in the HTML-rendered text. Added an inline style to the HTML element for each tweet to force whitespace preservation.

Also added "Start Over" button for returning to the homepage.