### PR TITLE
# Worker - Bug Fix

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -17,7 +17,7 @@ def make_thread(text, preserve_whitespace=False):
         j = len(tweet)
         # record punctuation marks as tweet breakpoints
         if re.match(punc, words[i]):
-            breakpoint = j + len(words[i])
+            breakpoint = j + len(words[i]) + 1
         # add word to tweet if length permits
         if j + len(words[i]) < 240:
             tweet += words[i]


### PR DESCRIPTION
# Worker - Bug Fix
Small bug fix in threading logic.
## Description
Threads intentionally split text blocks on whitespaces and/or punctuation marks. Corrected logic to break *after* punctuation rather than before. This corrects strange hanging punctuation marks, such as "!" and "?" at the beginning of tweets.