### PR TITLE
OAuth1 Offload

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import env
 from worker import *
 from flask import Flask, request, render_template, redirect, session
-import tweepy
 
 app = Flask(__name__)
 app.config.update(
@@ -23,30 +22,13 @@ def go():
 
 @app.route('/auth', methods=['POST'])
 def auth():
-    try:
-        session['AUTH_TOKEN']
-        session['AUTH_TOKEN_SECRET']
-        redirect_url = '/share'
-    except Exception:
-        auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET, env.CALLBACK_URL)
-        redirect_url = auth.get_authorization_url()
-        session['REQUEST_TOKEN'] = auth.request_token
-    finally:
-        return redirect(redirect_url)
+    url = initiate_oauth()
+    return redirect(url)
 
 @app.route('/callback', methods=['GET'])
 def callback():
-    auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET)
-    try:
-        auth.request_token = session['REQUEST_TOKEN']
-        verifier = request.args.get('oauth_verifier')
-        auth.get_access_token(verifier)
-        session['AUTH_TOKEN'],session['AUTH_TOKEN_SECRET'] = auth.access_token, auth.access_token_secret
-        redirect_url = '/share'
-    except Exception:
-        redirect_url = '/'
-    finally:
-        return redirect(redirect_url)
+    url = oauth_callback()
+    return redirect(url)
 
 @app.route('/share', methods=['GET'])
 def share():

--- a/worker.py
+++ b/worker.py
@@ -1,4 +1,36 @@
 import re
+import env
+import tweepy
+from flask import session, request
+
+def initiate_oauth():
+    """
+    return: str
+    """
+    try:
+        session['AUTH_TOKEN']
+        session['AUTH_TOKEN_SECRET']
+        redirect_url = '/share'
+    except Exception:
+        auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET, env.CALLBACK_URL)
+        redirect_url = auth.get_authorization_url()
+        session['REQUEST_TOKEN'] = auth.request_token
+    return redirect_url
+
+def oauth_callback():
+    """
+    return: str
+    """
+    auth = tweepy.OAuthHandler(env.TWITTER_API_KEY, env.TWITTER_API_SECRET)
+    try:
+        auth.request_token = session['REQUEST_TOKEN']
+        verifier = request.args.get('oauth_verifier')
+        auth.get_access_token(verifier)
+        session['AUTH_TOKEN'],session['AUTH_TOKEN_SECRET'] = auth.access_token, auth.access_token_secret
+        redirect_url = '/share'
+    except Exception:
+        redirect_url = '/'
+    return redirect_url
 
 def make_thread(text, preserve_whitespace=False):
     """


### PR DESCRIPTION
# OAuth1 Offload
Moved Oauth1 logic to `worker.py`.
## Description
As the app continues to grow in complexity, `app.py` will continue to grow. Moving forward, `app.py` will serve only the required Flask logic, whereas `worker.py` will serve other back-end logic.

The last commit message shows the app crashing inside a try/except block despite catching the general `Exception`. This occurred on an Ubuntu 16.04 virtual machine running Python 3.5 and could not be replicated on a Windows 10 machine running Python 3.7. Assuming this is a Flask/Python versioning problem, no issue has been created at this time.